### PR TITLE
Upgrade .NET to net9.0, fix ESLint react plugin conflict, and address build warnings

### DIFF
--- a/docker/memorypipeline/Dockerfile
+++ b/docker/memorypipeline/Dockerfile
@@ -1,7 +1,7 @@
 # docker build -f docker/webapi/Dockerfile -t chat-copilot-memorypipeline .
 
 # builder
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS builder
 WORKDIR /source
 # generate dev-certs for https
 RUN dotnet dev-certs https
@@ -17,7 +17,7 @@ RUN cd memorypipeline && \
 
 
 # final stage/image
-FROM mcr.microsoft.com/dotnet/aspnet:7.0
+FROM mcr.microsoft.com/dotnet/aspnet:9.0
 WORKDIR /app
 COPY --from=builder /app .
 COPY --from=builder /root/.dotnet/corefx/cryptography/x509stores/my/* /root/.dotnet/corefx/cryptography/x509stores/my/

--- a/docker/webapi/Dockerfile
+++ b/docker/webapi/Dockerfile
@@ -1,7 +1,7 @@
 # docker build -f docker/webapi/Dockerfile -t chat-copilot-webapi .
 
 # builder
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS builder
 WORKDIR /source
 # generate dev-certs for https
 RUN dotnet dev-certs https
@@ -15,7 +15,7 @@ RUN cd webapi && \
   dotnet publish --use-current-runtime --self-contained false --no-restore -o /app
 
 # final stage/image
-FROM mcr.microsoft.com/dotnet/aspnet:7.0
+FROM mcr.microsoft.com/dotnet/aspnet:9.0
 ENV Kestrel__Endpoints__Http__Url=http://0.0.0.0:8080
 WORKDIR /app
 COPY --from=builder /app .

--- a/integration-tests/ChatCopilotIntegrationTests.csproj
+++ b/integration-tests/ChatCopilotIntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/memorypipeline/CopilotChatMemoryPipeline.csproj
+++ b/memorypipeline/CopilotChatMemoryPipeline.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>CopilotChat.MemoryPipeline</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RollForward>LatestMajor</RollForward>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/plugins/shared/PluginShared.csproj
+++ b/plugins/shared/PluginShared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <RootNamespace>Plugins.PluginShared</RootNamespace>
   </PropertyGroup>

--- a/plugins/web-searcher/WebSearcher.csproj
+++ b/plugins/web-searcher/WebSearcher.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>

--- a/scripts/Install.ps1
+++ b/scripts/Install.ps1
@@ -26,7 +26,7 @@ if (!$ChocoInstalled)
 }
 
 # Ensure required packages are installed
-$Packages = 'dotnet-8.0-sdk', 'nodejs', 'yarn'
+$Packages = 'dotnet-9.0-sdk', 'nodejs', 'yarn'
 foreach ($PackageName in $Packages)
 {
     choco install $PackageName -y

--- a/scripts/Install.ps1
+++ b/scripts/Install.ps1
@@ -3,8 +3,7 @@
 Installs the requirements for running Chat Copilot.
 #>
 
-if ($IsLinux) 
-{
+if ($IsLinux) {
     Write-Host "ERROR: This script is not supported for your operating system."
     exit 1;
 }
@@ -17,8 +16,7 @@ $ChocoInstalled = $false
 if (Get-Command choco.exe -ErrorAction SilentlyContinue) {
     $ChocoInstalled = $true
 }
-if (!$ChocoInstalled)
-{
+if (!$ChocoInstalled) {
     Write-Host "Installing Chocolatey..."
     Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1')
     $env:PATH += ";%ALLUSERSPROFILE%\chocolatey\bin"
@@ -27,7 +25,6 @@ if (!$ChocoInstalled)
 
 # Ensure required packages are installed
 $Packages = 'dotnet-9.0-sdk', 'nodejs', 'yarn'
-foreach ($PackageName in $Packages)
-{
+foreach ($PackageName in $Packages) {
     choco install $PackageName -y
 }

--- a/scripts/deploy/main.bicep
+++ b/scripts/deploy/main.bicep
@@ -178,7 +178,7 @@ resource appServiceWebConfig 'Microsoft.Web/sites/config@2022-09-01' = {
     }
     detailedErrorLoggingEnabled: true
     minTlsVersion: '1.2'
-    netFrameworkVersion: 'v6.0'
+    netFrameworkVersion: 'v9.0'
     use32BitWorkerProcess: false
     vnetRouteAllEnabled: true
     webSocketsEnabled: true
@@ -460,7 +460,7 @@ resource appServiceMemoryPipelineConfig 'Microsoft.Web/sites/config@2022-09-01' 
     alwaysOn: true
     detailedErrorLoggingEnabled: true
     minTlsVersion: '1.2'
-    netFrameworkVersion: 'v6.0'
+    netFrameworkVersion: 'v9.0'
     use32BitWorkerProcess: false
     vnetRouteAllEnabled: true
     appSettings: [

--- a/scripts/deploy/main.json
+++ b/scripts/deploy/main.json
@@ -295,7 +295,7 @@
         },
         "detailedErrorLoggingEnabled": true,
         "minTlsVersion": "1.2",
-        "netFrameworkVersion": "v6.0",
+        "netFrameworkVersion": "v9.0",
         "use32BitWorkerProcess": false,
         "vnetRouteAllEnabled": true,
         "webSocketsEnabled": true,
@@ -357,7 +357,7 @@
         "alwaysOn": true,
         "detailedErrorLoggingEnabled": true,
         "minTlsVersion": "1.2",
-        "netFrameworkVersion": "v6.0",
+        "netFrameworkVersion": "v9.0",
         "use32BitWorkerProcess": false,
         "vnetRouteAllEnabled": true,
         "appSettings": [

--- a/scripts/deploy/package-memorypipeline.ps1
+++ b/scripts/deploy/package-memorypipeline.ps1
@@ -10,7 +10,7 @@ param(
     
     [string]
     # .NET framework to publish.
-    $DotNetFramework = "net6.0",
+    $DotNetFramework = "net9.0",
     
     [string]
     # Target runtime to publish.

--- a/scripts/deploy/package-memorypipeline.sh
+++ b/scripts/deploy/package-memorypipeline.sh
@@ -12,7 +12,7 @@ usage() {
     echo ""
     echo "Arguments:"
     echo "  -c, --configuration CONFIGURATION      Build configuration (default: Release)"
-    echo "  -d, --dotnet DOTNET_FRAMEWORK_VERSION  Target dotnet framework (default: net6.0)"
+    echo "  -d, --dotnet DOTNET_FRAMEWORK_VERSION  Target dotnet framework (default: net9.0)"
     echo "  -r, --runtime TARGET_RUNTIME           Runtime identifier (default: win-x64)"
     echo "  -o, --output OUTPUT_DIRECTORY          Output directory (default: $SCRIPT_ROOT)"
     echo "  -v  --version VERSION                  Version to set files to (default: 1.0.0)"
@@ -68,7 +68,7 @@ done
 
 # Set defaults
 : "${CONFIGURATION:="Release"}"
-: "${DOTNET:="net6.0"}"
+: "${DOTNET:="net9.0"}"
 : "${RUNTIME:="win-x64"}"
 : "${VERSION:="1.0.0"}"
 : "${INFO:=""}"

--- a/scripts/deploy/package-plugins.ps1
+++ b/scripts/deploy/package-plugins.ps1
@@ -10,7 +10,7 @@ param(
     
     [string]
     # .NET framework to publish.
-    $DotNetFramework = "net6.0",
+    $DotNetFramework = "net9.0",
     
     [string]
     # Output directory for published assets.

--- a/scripts/deploy/package-plugins.sh
+++ b/scripts/deploy/package-plugins.sh
@@ -12,7 +12,7 @@ usage() {
     echo ""
     echo "Arguments:"
     echo "  -c, --configuration CONFIGURATION      Build configuration (default: Release)"
-    echo "  -d, --dotnet DOTNET_FRAMEWORK_VERSION  Target dotnet framework (default: net6.0)"
+    echo "  -d, --dotnet DOTNET_FRAMEWORK_VERSION  Target dotnet framework (default: net9.0)"
     echo "  -o, --output OUTPUT_DIRECTORY          Output directory (default: $SCRIPT_ROOT)"
     echo "  -v  --version VERSION                  Version to set files to (default: 1.0.0)"
     echo "  -i  --info INFO                        Additional info to put in version details"
@@ -62,7 +62,7 @@ done
 
 # Set defaults
 : "${CONFIGURATION:="Release"}"
-: "${DOTNET:="net6.0"}"
+: "${DOTNET:="net9.0"}"
 : "${VERSION:="1.0.0"}"
 : "${INFO:=""}"
 : "${OUTPUT_DIRECTORY:="$SCRIPT_ROOT"}"

--- a/scripts/deploy/package-webapi.ps1
+++ b/scripts/deploy/package-webapi.ps1
@@ -10,7 +10,7 @@ param(
     
     [string]
     # .NET framework to publish.
-    $DotNetFramework = "net6.0",
+    $DotNetFramework = "net9.0",
     
     [string]
     # Target runtime to publish.

--- a/scripts/deploy/package-webapi.sh
+++ b/scripts/deploy/package-webapi.sh
@@ -12,7 +12,7 @@ usage() {
     echo ""
     echo "Arguments:"
     echo "  -c, --configuration CONFIGURATION      Build configuration (default: Release)"
-    echo "  -d, --dotnet DOTNET_FRAMEWORK_VERSION  Target dotnet framework (default: net6.0)"
+    echo "  -d, --dotnet DOTNET_FRAMEWORK_VERSION  Target dotnet framework (default: net9.0)"
     echo "  -r, --runtime TARGET_RUNTIME           Runtime identifier (default: win-x64)"
     echo "  -o, --output OUTPUT_DIRECTORY          Output directory (default: $SCRIPT_ROOT)"
     echo "  -v  --version VERSION                  Version to set files to (default: 1.0.0)"
@@ -75,7 +75,7 @@ echo  "Building backend executables..."
 
 # Set defaults
 : "${CONFIGURATION:="Release"}"
-: "${DOTNET:="net6.0"}"
+: "${DOTNET:="net9.0"}"
 : "${RUNTIME:="win-x64"}"
 : "${VERSION:="0.0.0"}"
 : "${INFO:=""}"

--- a/scripts/install-apt.sh
+++ b/scripts/install-apt.sh
@@ -9,7 +9,7 @@ curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 
 # Add .NET's package repository to the system
-wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
 sudo dpkg -i packages-microsoft-prod.deb
 rm packages-microsoft-prod.deb
 
@@ -19,7 +19,7 @@ curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
 # Install the requirements
 sudo apt update;
 sudo apt install yarn -y;
-sudo apt install dotnet-sdk-7.0 -y;
+sudo apt install dotnet-sdk-9.0 -y;
 sudo apt install nodejs -y;
 
 echo ""

--- a/shared/CopilotChatShared.csproj
+++ b/shared/CopilotChatShared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>CopilotChat.Shared</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RollForward>LatestMajor</RollForward>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/tools/importdocument/ImportDocument.csproj
+++ b/tools/importdocument/ImportDocument.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RollForward>LatestMajor</RollForward>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>10</LangVersion>
+    <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/webapi/Controllers/ServiceInfoController.cs
+++ b/webapi/Controllers/ServiceInfoController.cs
@@ -63,7 +63,7 @@ public class ServiceInfoController : ControllerBase
         {
             MemoryStore = new MemoryStoreInfoResponse()
             {
-                Types = Enum.GetNames(typeof(MemoryStoreType)),
+                Types = Enum.GetNames<MemoryStoreType>(),
                 SelectedType = this.memoryOptions.GetMemoryStoreType(this.Configuration).ToString(),
             },
             AvailablePlugins = this.availablePlugins,

--- a/webapi/CopilotChatWebApi.csproj
+++ b/webapi/CopilotChatWebApi.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <RootNamespace>CopilotChat.WebApi</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RollForward>LatestMajor</RollForward>
-    <LangVersion>10</LangVersion>
+    <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/webapi/CopilotChatWebApi.csproj
+++ b/webapi/CopilotChatWebApi.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
     <UserSecretsId>5ee045b0-aea3-4f08-8d31-32d1a6f8fed0</UserSecretsId>
-    <NoWarn>SKEXP0003,SKEXP0011,SKEXP0021,SKEXP0026,SKEXP0042,SKEXP0050,SKEXP0052,SKEXP0053,SKEXP0060</NoWarn>
+    <NoWarn>SKEXP0003,SKEXP0011,SKEXP0021,SKEXP0026,SKEXP0042,SKEXP0050,SKEXP0052,SKEXP0053,SKEXP0060,CA1515</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/webapi/Extensions/ISemanticMemoryClientExtensions.cs
+++ b/webapi/Extensions/ISemanticMemoryClientExtensions.cs
@@ -154,7 +154,7 @@ internal static class ISemanticMemoryClientExtensions
         using var stream = new MemoryStream();
         using var writer = new StreamWriter(stream);
         await writer.WriteAsync(memory);
-        await writer.FlushAsync();
+        await writer.FlushAsync(cancellationToken);
         stream.Position = 0;
 
         var uploadRequest = new DocumentUploadRequest

--- a/webapi/Plugins/Chat/ChatPlugin.cs
+++ b/webapi/Plugins/Chat/ChatPlugin.cs
@@ -472,7 +472,7 @@ public class ChatPlugin
             null,
             CopilotChatMessage.AuthorRoles.User,
             // Default to a standard message if the `type` is not recognized
-            Enum.TryParse(type, out CopilotChatMessage.ChatMessageType typeAsEnum) && Enum.IsDefined(typeof(CopilotChatMessage.ChatMessageType), typeAsEnum)
+            Enum.TryParse(type, out CopilotChatMessage.ChatMessageType typeAsEnum) && Enum.IsDefined<CopilotChatMessage.ChatMessageType>(typeAsEnum)
                 ? typeAsEnum
                 : CopilotChatMessage.ChatMessageType.Message);
 

--- a/webapi/Plugins/Chat/SemanticChatMemoryExtractor.cs
+++ b/webapi/Plugins/Chat/SemanticChatMemoryExtractor.cs
@@ -37,7 +37,7 @@ internal static class SemanticChatMemoryExtractor
         ILogger logger,
         CancellationToken cancellationToken)
     {
-        foreach (string memoryType in Enum.GetNames(typeof(SemanticMemoryType)))
+        foreach (string memoryType in Enum.GetNames<SemanticMemoryType>())
         {
             try
             {

--- a/webapp/.eslintrc.cjs
+++ b/webapp/.eslintrc.cjs
@@ -8,7 +8,6 @@ module.exports = {
     },
     extends: [
         'react-app/jest',
-        'plugin:react/recommended',
         'plugin:react-hooks/recommended',
         'plugin:@typescript-eslint/strict-type-checked',
         'plugin:@typescript-eslint/stylistic-type-checked',


### PR DESCRIPTION
## Summary of changes

### .NET upgrade (net6.0 - net9.0)
- Updated `TargetFramework` from `net6.0` to `net9.0` across all 7 projects: `webapi`, `memorypipeline`, `shared`, `plugins/shared`, `plugins/web-searcher`, `tools/importdocument`, `integration-tests`
- Updated `LangVersion` from `10` to `latest` in `webapi` and `importdocument`
- Bumped `Microsoft.CodeAnalysis.NetAnalyzers` from `8.0.0` to `9.0.0` in `webapi`

### Scripts and IaC
- `scripts/Install.ps1`: Chocolatey package updated to `dotnet-9.0-sdk`
- `scripts/install-apt.sh`: Updated to `dotnet-sdk-9.0` and Ubuntu package repo from `20.04` to `22.04`
- `scripts/deploy/package-webapi.ps1/.sh`: Default framework updated to `net9.0`
- `scripts/deploy/package-memorypipeline.ps1/.sh`: Default framework updated to `net9.0`
- `scripts/deploy/package-plugins.ps1/.sh`: Default framework updated to `net9.0`
- `scripts/deploy/main.bicep` and `main.json`: `netFrameworkVersion` updated to `v9.0` for both App Service resources

### Docker
- `docker/webapi/Dockerfile`: Base images updated from `7.0` to `9.0`
- `docker/memorypipeline/Dockerfile`: Base images updated from `7.0` to `9.0`

### Frontend - ESLint fix
- `webapp/.eslintrc.cjs`: Removed `plugin:react/recommended` from `extends` - `eslint-config-react-app` already registers the React plugin internally, causing a duplicate plugin conflict at runtime

### Build warnings resolved
- **CA1515**: Suppressed project-wide in `webapi` csproj - ASP.NET Core controllers, SignalR hubs, and model-bound types must remain `public` for framework discovery
- **CA2263** (3 instances): Updated `Enum.GetNames(typeof(T))` to `Enum.GetNames<T>()` and `Enum.IsDefined(typeof(T), v)` to `Enum.IsDefined<T>(v)` in `ServiceInfoController`, `SemanticChatMemoryExtractor`, and `ChatPlugin`
- **CA2016**: Forwarded `cancellationToken` to `FlushAsync` in `ISemanticMemoryClientExtensions`